### PR TITLE
s2221, ta 9032: up version to grab version of datalink service using …

### DIFF
--- a/sc2links/build.gradle
+++ b/sc2links/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     compile 'org.opencadc:cadc-util:1.+'
     compile 'org.opencadc:cadc-log:1.+'
     compile 'org.opencadc:cadc-wcs:[2.0,3.0)'
-    compile 'org.opencadc:caom2-datalink-server:[1.8,)'
+    compile 'org.opencadc:caom2-datalink-server:[1.7.1,)'
     compile 'org.opencadc:cadc-access-control-identity:1.+'
     compile 'org.opencadc:cadc-vosi:[1.0.1,2.0)'
  

--- a/sc2links/build.gradle
+++ b/sc2links/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     compile 'org.opencadc:cadc-util:1.+'
     compile 'org.opencadc:cadc-log:1.+'
     compile 'org.opencadc:cadc-wcs:[2.0,3.0)'
-    compile 'org.opencadc:caom2-datalink-server:[1.6,)'
+    compile 'org.opencadc:caom2-datalink-server:[1.8,)'
     compile 'org.opencadc:cadc-access-control-identity:1.+'
     compile 'org.opencadc:cadc-vosi:[1.0.1,2.0)'
  


### PR DESCRIPTION
…latest resolver list.

caom2service has a pull request (#31) that this is dependent on. It is dependent on the version of the caom2-artifact-resolvers associated with s2221 (version 1.1.0) in order to have access to the new resolvers (SDSS, NOAO, XMM, CHANDRA, etc.) 