### PR TITLE
update to TAP-1.1 style capabilities

### DIFF
--- a/sc2tap/build.gradle
+++ b/sc2tap/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.7
 
 group = 'ca.nrc.cadc'
 
-version = '1002'
+version = '1003'
 
 war {
     archiveName = project.name + '##' + project.version + '.war'
@@ -41,6 +41,7 @@ dependencies {
 
     testCompile 'junit:junit:4.+'
     
+    intTestCompile 'org.opencadc:cadc-tap:[1.0,)'
     intTestCompile 'org.opencadc:cadc-test-vosi:[1.0.4,)'
     intTestCompile 'org.opencadc:cadc-test-uws:[1.1.2,)'
     intTestCompile 'org.opencadc:cadc-test-tap:[1.1.2,)'

--- a/sc2tap/src/main/java/ca/nrc/cadc/sc2tap/QueryJobManager.java
+++ b/sc2tap/src/main/java/ca/nrc/cadc/sc2tap/QueryJobManager.java
@@ -68,7 +68,6 @@
 package ca.nrc.cadc.sc2tap;
 
 import ca.nrc.cadc.auth.ACIdentityManager;
-import ca.nrc.cadc.tap.QueryRunner;
 import ca.nrc.cadc.uws.server.JobExecutor;
 import ca.nrc.cadc.uws.server.JobPersistence;
 import ca.nrc.cadc.uws.server.JobUpdater;
@@ -95,7 +94,7 @@ public class QueryJobManager extends SimpleJobManager
 
         // max threads: 6 == number of simultaneously running async queries (per
         // web server), plus sync queries, plus VOSI-tables queries
-        JobExecutor jobExec = new ThreadPoolExecutor(jobUpdater, QueryRunner.class, 6);
+        JobExecutor jobExec = new ThreadPoolExecutor(jobUpdater, QueryRunnerImpl.class, 6);
 
         super.setJobPersistence(jobPersist);
         super.setJobExecutor(jobExec);

--- a/sc2tap/src/main/java/ca/nrc/cadc/sc2tap/QueryRunnerImpl.java
+++ b/sc2tap/src/main/java/ca/nrc/cadc/sc2tap/QueryRunnerImpl.java
@@ -62,51 +62,39 @@
 *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
 *                                       <http://www.gnu.org/licenses/>.
 *
-*  $Revision: 6 $
-*
 ************************************************************************
 */
 
 package ca.nrc.cadc.sc2tap;
 
 
-import ca.nrc.cadc.auth.AuthMethod;
-import ca.nrc.cadc.reg.Capabilities;
-import ca.nrc.cadc.reg.Capability;
-import ca.nrc.cadc.reg.Interface;
-import ca.nrc.cadc.reg.Standards;
-import ca.nrc.cadc.vosi.CapabilitiesTest;
-import java.net.URI;
+import ca.nrc.cadc.db.DBUtil;
+import ca.nrc.cadc.tap.QueryRunner;
+import javax.sql.DataSource;
 import org.apache.log4j.Logger;
-import org.junit.Assert;
 
 /**
  *
  * @author pdowler
  */
-public class VosiCapabilitiesTest extends CapabilitiesTest
-{
-    private static final Logger log = Logger.getLogger(VosiCapabilitiesTest.class);
+public class QueryRunnerImpl extends QueryRunner {
+    private static final Logger log = Logger.getLogger(QueryRunnerImpl.class);
 
-    public VosiCapabilitiesTest() 
-    { 
-        super(URI.create("ivo://cadc.nrc.ca/sc2tap"));
+    public QueryRunnerImpl() { 
     }
     
     @Override
-    protected void validateContent(Capabilities caps) throws Exception {
-        super.validateContent(caps);
-        
-        // TAP-1.1
-        Capability tap = caps.findCapability(Standards.TAP_10);
-        Interface base = tap.findInterface(AuthMethod.ANON, Standards.INTERFACE_PARAM_HTTP);
-        Assert.assertNotNull("base", base);
-        Assert.assertTrue("anon base", base.getSecurityMethods().contains(Standards.SECURITY_METHOD_ANON));
-        Assert.assertTrue("cert base", base.getSecurityMethods().contains(Standards.SECURITY_METHOD_CERT));
-        Assert.assertTrue("cookie base", base.getSecurityMethods().contains(Standards.SECURITY_METHOD_COOKIE));
+    protected DataSource getUploadDataSource() throws Exception {
+        return getQueryDataSource();
+    }
 
-        Capability tables = caps.findCapability(Standards.VOSI_TABLES_11);
-        Assert.assertNotNull("tables", tables);
-        Assert.assertNotNull("anon tables", tables.findInterface(Standards.SECURITY_METHOD_ANON, Standards.INTERFACE_PARAM_HTTP));
+    @Override
+    protected DataSource getTapSchemaDataSource() throws Exception {
+        return getQueryDataSource();
+    }
+
+    @Override
+    protected DataSource getQueryDataSource() throws Exception {
+        return DBUtil.findJNDIDataSource("jdbc/tapuser");
     }
 }

--- a/sc2tap/src/main/java/ca/nrc/cadc/sc2tap/ServiceAvailabilityImpl.java
+++ b/sc2tap/src/main/java/ca/nrc/cadc/sc2tap/ServiceAvailabilityImpl.java
@@ -124,10 +124,10 @@ public class ServiceAvailabilityImpl implements AvailabilityPlugin {
             // datasource names are the QueryRunner defaults
             String[] uploadTest = getTapUploadTest();
             // create table
-            cr = new CheckDataSource("jdbc/tapuploadadm", uploadTest[0], false);
+            cr = new CheckDataSource("jdbc/tapuser", uploadTest[0], false);
             cr.check();
             // drop table
-            cr = new CheckDataSource("jdbc/tapuploadadm", uploadTest[1], false);
+            cr = new CheckDataSource("jdbc/tapuser", uploadTest[1], false);
             cr.check();
 
             // certificate need to call cred

--- a/sc2tap/src/main/webapp/META-INF/context.xml
+++ b/sc2tap/src/main/webapp/META-INF/context.xml
@@ -3,17 +3,38 @@
 
     <WatchedResource>WEB-INF/web.xml</WatchedResource>
 
-    <!-- development server -->
-    <ResourceLink name="jdbc/uws"
-        global="jdbc/sandbox-tapadm"
-        type="javax.sql.DataSource" />
-        
-    <ResourceLink name="jdbc/tapuser"
-        global="jdbc/sandbox-tapuser"
-        type="javax.sql.DataSource" />
-
-    <ResourceLink name="jdbc/tapuploadadm"
-        global="jdbc/sandbox-tapuser"
-        type="javax.sql.DataSource" />
+    <Resource name="jdbc/tapadm"
+        auth="Container"
+        type="javax.sql.DataSource"
+        factory="org.apache.tomcat.jdbc.pool.DataSourceFactory" closeMethod="close"
+        minEvictableIdleTimeMillis="60000" timeBetweenEvictionRunsMillis="30000"
+        maxWait="20000"
+        initialSize="0"  minIdle="0" maxIdle="${sc2tap.tapadm.maxActive}" maxActive="${sc2tap.tapadm.maxActive}" 
+        username="${sc2tap.tapadm.username}" password="${sc2tap.tapadm.password}"
+        driverClassName="org.postgresql.Driver" url="${sc2tap.tapadm.url}"
+        removeAbandoned="false"
+        testWhileIdle="true" testOnBorrow="true" validationQuery="select 123" />
+    <Resource name="jdbc/uws"
+        auth="Container"
+        type="javax.sql.DataSource"
+        factory="org.apache.tomcat.jdbc.pool.DataSourceFactory" closeMethod="close"
+        minEvictableIdleTimeMillis="60000" timeBetweenEvictionRunsMillis="30000"
+        maxWait="20000"
+        initialSize="0" minIdle="0" maxIdle="${sc2tap.uws.maxActive}" maxActive="${sc2tap.uws.maxActive}"
+        username="${sc2tap.uws.username}" password="${sc2tap.uws.password}"
+        driverClassName="org.postgresql.Driver" url="${sc2tap.uws.url}"
+        removeAbandoned="false"
+        testOnBorrow="true" validationQuery="select 123" />
+    <Resource name="jdbc/tapuser"
+        auth="Container"
+        type="javax.sql.DataSource"
+        factory="org.apache.tomcat.jdbc.pool.DataSourceFactory" closeMethod="close"
+        minEvictableIdleTimeMillis="60000" timeBetweenEvictionRunsMillis="30000"
+        maxWait="20000"
+        initialSize="0" minIdle="0" maxIdle="${sc2tap.tapuser.maxActive}" maxActive="${sc2tap.tapuser.maxActive}"
+        username="${sc2tap.tapuser.username}" password="${sc2tap.tapuser.password}"
+        driverClassName="org.postgresql.Driver" url="${sc2tap.tapuser.url}"
+        removeAbandoned="false"
+        testOnBorrow="true" validationQuery="select 123" />
     
 </Context>

--- a/sc2tap/src/main/webapp/capabilities.xml
+++ b/sc2tap/src/main/webapp/capabilities.xml
@@ -18,7 +18,8 @@
   
   <capability standardID="vos://cadc.nrc.ca~vospace/CADC/std/Logging#control-1.0">
     <interface xsi:type="vs:ParamHTTP" role="std" version="1.0">
-      <accessURL use="full">https://example.net/sc2tap/logControl</accessURL>     
+      <accessURL use="full">https://example.net/sc2tap/logControl</accessURL> 
+      <securityMethod standardID="ivo://ivoa.net/sso#BasicAA"/>    
     </interface> 
   </capability> 
 
@@ -26,78 +27,19 @@
     <interface xsi:type="vs:ParamHTTP" role="std" version="1.1">
       <accessURL use="base">https://example.net/sc2tap/tables</accessURL>
     </interface>
-    <interface xsi:type="vs:ParamHTTP" role="std" version="1.1">
-      <accessURL use="base">https://example.net/sc2tap/auth-tables</accessURL>
-      <securityMethod standardID="ivo://ivoa.net/sso#BasicAA"/>
-    </interface>
-    <interface xsi:type="vs:ParamHTTP" role="std" version="1.1">
-      <accessURL use="base">https://example.net/sc2tap/tables</accessURL>
-      <securityMethod standardID="ivo://ivoa.net/sso#cookie"/>
-    </interface>
-    <interface xsi:type="vs:ParamHTTP" role="std" version="1.1">
-      <accessURL use="base">https://example.net/sc2tap/tables</accessURL>
-      <securityMethod standardID="ivo://ivoa.net/sso#tls-with-certificate"/>
-    </interface>
   </capability>
 
   <!-- TAP-1.1 -->
   <capability standardID="ivo://ivoa.net/std/TAP" 
         xmlns:tr="http://www.ivoa.net/xml/TAPRegExt/v1.0" xsi:type="tr:TableAccess">
-    <!-- anon base URL for TAP-1.0 clients -->
     <interface xsi:type="vs:ParamHTTP"
                role="std" version="1.1">
       <accessURL use="base">https://example.net/sc2tap</accessURL>
-    </interface>
-    
-    <interface xsi:type="uws:Async"
-               xmlns:uws="http://www.ivoa.net/xml/UWSRegExt/v0.1"
-               role="std" version="1.1">
-      <accessURL use="base">https://example.net/sc2tap/async</accessURL>
-    </interface>
-    <interface xsi:type="uws:Async"
-               xmlns:uws="http://www.ivoa.net/xml/UWSRegExt/v0.1"
-               role="std" version="1.1">
-      <accessURL use="base">https://example.net/sc2tap/auth-async</accessURL>
-      <securityMethod standardID="ivo://ivoa.net/sso#BasicAA"/>
-    </interface>
-    <interface xsi:type="uws:Async"
-               xmlns:uws="http://www.ivoa.net/xml/UWSRegExt/v0.1"
-               role="std" version="1.1">
-      <accessURL use="base">https://example.net/sc2tap/async</accessURL>
-      <securityMethod
-              standardID="ivo://ivoa.net/sso#tls-with-certificate"/>
-    </interface>
-    <interface xsi:type="uws:Async"
-               xmlns:uws="http://www.ivoa.net/xml/UWSRegExt/v0.1"
-               role="std" version="1.1">
-      <accessURL use="base">https://example.net/sc2tap/async</accessURL>
-      <securityMethod
-              standardID="ivo://ivoa.net/sso#cookie"/>
-    </interface>
-    <interface xsi:type="uws:Sync"
-               xmlns:uws="http://www.ivoa.net/xml/UWSRegExt/v0.1"
-               role="std" version="1.1">
-      <accessURL use="base"> https://example.net/sc2tap/sync </accessURL>
-    </interface>
-    <interface xsi:type="uws:Sync"
-               xmlns:uws="http://www.ivoa.net/xml/UWSRegExt/v0.1"
-               role="std" version="1.1">
-      <accessURL use="base">https://example.net/sc2tap/auth-sync</accessURL>
-      <securityMethod standardID="ivo://ivoa.net/sso#BasicAA"/>
-    </interface>
-    <interface xsi:type="uws:Sync"
-               xmlns:uws="http://www.ivoa.net/xml/UWSRegExt/v0.1"
-               role="std" version="1.1">
-      <accessURL use="base">https://example.net/sc2tap/sync</accessURL>
+      <securityMethod/>
+      <securityMethod standardID="ivo://ivoa.net/sso#cookie"/>
       <securityMethod standardID="ivo://ivoa.net/sso#tls-with-certificate"/>
     </interface>
-    <interface xsi:type="uws:Sync"
-               xmlns:uws="http://www.ivoa.net/xml/UWSRegExt/v0.1"
-               role="std" version="1.1">
-      <accessURL use="base">https://example.net/sc2tap/sync</accessURL>
-      <securityMethod standardID="ivo://ivoa.net/sso#cookie"/>
-    </interface>
-
+    
     <dataModel ivo-id="ivo://ivoa.net/std/ObsCore/v1.1">ObsCore-1.1</dataModel>
 
     <language>
@@ -110,9 +52,6 @@
             </feature>
             <feature>
                 <form>CIRCLE</form>
-            </feature>
-            <feature>
-                <form>BOX</form>
             </feature>
             <feature>
                 <form>POLYGON</form>


### PR DESCRIPTION
switch to creating connection pools inside context.xml with system props from catalina.properties; should be a more self-documenting approach

** requires config change on server before being deployed