### PR TITLE
alma-resolver-fix. Added CaomArtifactResolver.properties to sc2links …

### DIFF
--- a/sc2links/build.gradle
+++ b/sc2links/build.gradle
@@ -15,25 +15,25 @@ sourceCompatibility = 1.7
 
 group = 'ca.nrc.cadc'
 
-version = '1000'
+version = '1001'
 
 war {
     archiveName = project.name + '##' + project.version + '.war'
 }
 
 dependencies {
-    compile 'log4j:log4j:1.2.+'
-    providedCompile 'javax.servlet:javax.servlet-api:3.1.+'
+    compile 'log4j:log4j:[1.2.0,)'
+    providedCompile 'javax.servlet:javax.servlet-api:[3.1.0,)'
     
-    compile 'org.opencadc:cadc-util:1.+'
-    compile 'org.opencadc:cadc-log:1.+'
+    compile 'org.opencadc:cadc-util:[1.0,)'
+    compile 'org.opencadc:cadc-log:[1.0,)'
     compile 'org.opencadc:cadc-wcs:[2.0,3.0)'
     compile 'org.opencadc:caom2-tap:[1.6.2,)'
     compile 'org.opencadc:caom2-datalink-server:[1.7.1,)'
-    compile 'org.opencadc:cadc-access-control-identity:1.+'
+    compile 'org.opencadc:cadc-access-control-identity:[1.0,)'
     compile 'org.opencadc:cadc-vosi:[1.0.1,2.0)'
  
-    testCompile 'junit:junit:4.+'
+    testCompile 'junit:junit:[4.0,)'
     
     intTestCompile 'org.opencadc:cadc-test-vosi:[1.0.2,)'
 }

--- a/sc2links/src/main/webapp/WEB-INF/classes/CaomArtifactResolver.properties
+++ b/sc2links/src/main/webapp/WEB-INF/classes/CaomArtifactResolver.properties
@@ -1,0 +1,33 @@
+#
+# artifact resolver configuration
+#
+# scheme:<class name of SchemeHandler impl>
+
+#ad=ca.nrc.cadc.caom2.artifact.resolvers.AdResolver
+ad=ca.nrc.cadc.caom2ops.AdCutoutGenerator
+chandra=ca.nrc.cadc.caom2.artifact.resolvers.ChandraResolver
+noao=ca.nrc.cadc.caom2.artifact.resolvers.NoaoResolver
+sdss=ca.nrc.cadc.caom2.artifact.resolvers.SdssResolver
+subaru=ca.nrc.cadc.caom2.artifact.resolvers.SubaruResolver
+xmm=ca.nrc.cadc.caom2.artifact.resolvers.XmmResolver
+
+# ALMA resolver for CADC URLs
+alma=ca.nrc.cadc.caom2.artifact.resolvers.CadcAlmaResolver
+
+# mast resolver for MAST/STScI URLs
+#mast=ca.nrc.cadc.caom2.artifact.resolvers.MastResolver
+
+# MAST resolver for CADC URLs
+#mast=ca.nrc.cadc.caom2.artifact.resolvers.CadcMastResolver
+mast=ca.nrc.cadc.caom2ops.CadcMastCutoutGenerator
+
+#vos=ca.nrc.cadc.caom2.artifact.resolvers.VOSpaceResolver
+vos=ca.nrc.cadc.caom2ops.VOSpaceCutoutGenerator
+
+# gemini resolver for GEMINI URLs
+#gemini=ca.nrc.cadc.caom2.artifact.resolvers.GeminiResolver
+
+# gemini resolver for CADC URLs
+#gemini=ca.nrc.cadc.caom2.artifact.resolvers.CadcGeminiResolver
+gemini=ca.nrc.cadc.caom2ops.CadcGeminiCutoutGenerator
+

--- a/sc2soda/build.gradle
+++ b/sc2soda/build.gradle
@@ -15,25 +15,25 @@ sourceCompatibility = 1.7
 
 group = 'ca.nrc.cadc'
 
-version = '1000'
+version = '1001'
 
 war {
     archiveName = project.name + '##' + project.version + '.war'
 }
 
 dependencies {
-    compile 'log4j:log4j:1.2.+'
-    providedCompile 'javax.servlet:javax.servlet-api:3.1.+'
+    compile 'log4j:log4j:[1.2.0,)'
+    providedCompile 'javax.servlet:javax.servlet-api:[3.1.0,)'
     
-    compile 'org.opencadc:cadc-util:1.+'
-    compile 'org.opencadc:cadc-log:1.+'
+    compile 'org.opencadc:cadc-util:[1.0,)'
+    compile 'org.opencadc:cadc-log:[1.0,)'
     compile 'org.opencadc:caom2-tap:[1.6.2,)'
     compile 'org.opencadc:caom2-soda-server:[1.1,)'
-    compile 'org.opencadc:cadc-access-control-identity:1.+'
+    compile 'org.opencadc:cadc-access-control-identity:[1.0,)'
     compile 'org.opencadc:cadc-vosi:[1.0.1,2.0)'
     compile 'org.opencadc:cadc-wcs:[2.0,3.0)'
  
-    testCompile 'junit:junit:4.+'
+    testCompile 'junit:junit:[4.0,)'
     
     intTestCompile 'org.opencadc:cadc-test-vosi:[1.0.2,)'
 }

--- a/sc2soda/src/main/webapp/WEB-INF/classes/CaomArtifactResolver.properties
+++ b/sc2soda/src/main/webapp/WEB-INF/classes/CaomArtifactResolver.properties
@@ -1,0 +1,33 @@
+#
+# artifact resolver configuration
+#
+# scheme:<class name of SchemeHandler impl>
+
+#ad=ca.nrc.cadc.caom2.artifact.resolvers.AdResolver
+ad=ca.nrc.cadc.caom2ops.AdCutoutGenerator
+chandra=ca.nrc.cadc.caom2.artifact.resolvers.ChandraResolver
+noao=ca.nrc.cadc.caom2.artifact.resolvers.NoaoResolver
+sdss=ca.nrc.cadc.caom2.artifact.resolvers.SdssResolver
+subaru=ca.nrc.cadc.caom2.artifact.resolvers.SubaruResolver
+xmm=ca.nrc.cadc.caom2.artifact.resolvers.XmmResolver
+
+# ALMA resolver for CADC URLs
+alma=ca.nrc.cadc.caom2.artifact.resolvers.CadcAlmaResolver
+
+# mast resolver for MAST/STScI URLs
+#mast=ca.nrc.cadc.caom2.artifact.resolvers.MastResolver
+
+# MAST resolver for CADC URLs
+#mast=ca.nrc.cadc.caom2.artifact.resolvers.CadcMastResolver
+mast=ca.nrc.cadc.caom2ops.CadcMastCutoutGenerator
+
+#vos=ca.nrc.cadc.caom2.artifact.resolvers.VOSpaceResolver
+vos=ca.nrc.cadc.caom2ops.VOSpaceCutoutGenerator
+
+# gemini resolver for GEMINI URLs
+#gemini=ca.nrc.cadc.caom2.artifact.resolvers.GeminiResolver
+
+# gemini resolver for CADC URLs
+#gemini=ca.nrc.cadc.caom2.artifact.resolvers.CadcGeminiResolver
+gemini=ca.nrc.cadc.caom2ops.CadcGeminiCutoutGenerator
+


### PR DESCRIPTION
…and sc2soda.

This fix adds the CadcAlmaResolver to the CaomArtifactResolver.properites file so that ALMA URI's can be resolved. Along with this change, some codes have been refactored resulting in files being updated and moved. The following is a list of modules updated as a result of this fix.
caom2service/caom2-tap
caom2service/caom2-datalink-server
caom2service/caom2-pkg-server
caom2service/caom2-soda-server
caom2/caom2-artifact-resolvers
caom2sandbox/sc2links
caom2sandbox/sc2soda